### PR TITLE
Asynchrony, Sampling, and Distance Maximality

### DIFF
--- a/CARL/include/carl/InputSample.h
+++ b/CARL/include/carl/InputSample.h
@@ -63,6 +63,6 @@ namespace carl
         std::optional<std::array<TransformT, static_cast<size_t>(Joint::COUNT)>> LeftHandJointPoses{};
         std::optional<std::array<TransformT, static_cast<size_t>(Joint::COUNT)>> RightHandJointPoses{};
 
-        static InputSample lerp(const InputSample& a, const InputSample& b, double t);
+        static InputSample Lerp(const InputSample& a, const InputSample& b, double t);
     };
 }

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -30,7 +30,7 @@ namespace carl
         // TODO: Figure out a better, more opaque type to return.
         arcana::manual_dispatcher<128>& callbackScheduler();
         // TODO: Figure out a better, more opaque type to return.
-        arcana::background_dispatcher<128>& processingScheduler();
+        //arcana::background_dispatcher<128>& processingScheduler();
         void tickCallbacks(arcana::cancellation& token);
 
     private:

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -31,6 +31,7 @@ namespace carl
         SchedulerT& callbackScheduler();
         SchedulerT& processingScheduler();
         void setLogger(std::function<void(std::string)> logger);
+        void log(std::string message);
         void tickCallbacks(arcana::cancellation& token);
 
     private:

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -21,16 +21,15 @@ namespace carl
     class Session {
     public:
         class Impl;
+        using SchedulerT = stdext::inplace_function<void(stdext::inplace_function<void(), 128>&&), 128>;
 
-        Session();
+        Session(size_t samplesPerSecond = 20, size_t maxActionDurationSeconds = 5, bool singleThreaded = false);
         ~Session();
 
         void addInput(InputSample);
 
-        // TODO: Figure out a better, more opaque type to return.
-        arcana::manual_dispatcher<128>& callbackScheduler();
-        // TODO: Figure out a better, more opaque type to return.
-        arcana::background_dispatcher<128>& processingScheduler();
+        SchedulerT& callbackScheduler();
+        SchedulerT& processingScheduler();
         void tickCallbacks(arcana::cancellation& token);
 
     private:

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -9,6 +9,8 @@
 
 #include "carl/InputSample.h"
 
+#include <arcana/threading/dispatcher.h>
+
 #include <memory>
 
 namespace carl
@@ -24,6 +26,12 @@ namespace carl
         ~Session();
 
         void addInput(InputSample);
+
+        // TODO: Figure out a better, more opaque type to return.
+        arcana::manual_dispatcher<128>& callbackScheduler();
+        // TODO: Figure out a better, more opaque type to return.
+        arcana::background_dispatcher<128>& processingScheduler();
+        void tickCallbacks(arcana::cancellation& token);
 
     private:
         friend class Impl;

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -30,6 +30,7 @@ namespace carl
 
         SchedulerT& callbackScheduler();
         SchedulerT& processingScheduler();
+        void setLogger(std::function<void(std::string)> logger);
         void tickCallbacks(arcana::cancellation& token);
 
     private:

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -30,7 +30,7 @@ namespace carl
         // TODO: Figure out a better, more opaque type to return.
         arcana::manual_dispatcher<128>& callbackScheduler();
         // TODO: Figure out a better, more opaque type to return.
-        //arcana::background_dispatcher<128>& processingScheduler();
+        arcana::background_dispatcher<128>& processingScheduler();
         void tickCallbacks(arcana::cancellation& token);
 
     private:

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -23,7 +23,7 @@ namespace carl
         class Impl;
         using SchedulerT = stdext::inplace_function<void(stdext::inplace_function<void(), 128>&&), 128>;
 
-        Session(size_t samplesPerSecond = 20, size_t maxActionDurationSeconds = 5, bool singleThreaded = false);
+        Session(bool singleThreaded = false);
         ~Session();
 
         void addInput(InputSample);

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -310,7 +310,7 @@ namespace carl::descriptor
         static NumberT Distance(const HandShape& a, const HandShape& b, gsl::span<const NumberT> tuning) {
             NumberT distance = 0;
             for (size_t idx = 0; idx < a.m_positions.size(); ++idx) {
-                distance += calculateDistance(a.m_positions[idx].distance(b.m_positions[idx]), tuning[idx]);
+                distance = std::max(distance, calculateDistance(a.m_positions[idx].distance(b.m_positions[idx]), tuning[idx]));
             }
             return distance;
         }
@@ -318,8 +318,8 @@ namespace carl::descriptor
         HandShape() = default;
 
     private:
-        static inline constexpr auto calculateDistance{ createDistanceFunction(0.005, 0.02) };
-        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.01, 0.03) };
+        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.005, 0.02) };
+        static inline constexpr auto calculateDistance{ createDistanceFunction(0.01, 0.03) };
         static inline constexpr NumberT CANONICAL_NORMALIZATION_LENGTH{0.1};
         std::array<trivial::Point, JOINTS.size()> m_positions{};
 
@@ -433,7 +433,7 @@ namespace carl::descriptor
                 a.m_wristOrientationSample,
                 b.m_wristOrientationSample,
                 TuningT::template getTuning<EgocentricWristOrientation<Handedness>>(tuning));
-            return handShapeDistance + wristOrientationDistance;
+            return std::max(handShapeDistance, wristOrientationDistance);
         }
 
         HandPose() = default;
@@ -559,7 +559,7 @@ namespace carl::descriptor
         EgocentricWristTranslation() = default;
 
     private:
-        static inline constexpr auto calculateDistance{ createDistanceFunction(0.3, 1.3) };
+        static inline constexpr auto calculateDistance{ createDistanceFunction(0.6, 1.2) };
         // The parameters of the above distance function are based on the assumption of 20fps,
         // so 30 is used to normalize the data to make the descriptor framerate independent.
         static inline constexpr NumberT DISTANCE_PARAMETERS_FRAMES_PER_SECOND{ 30 };
@@ -617,7 +617,7 @@ namespace carl::descriptor
                 a.m_wristTranslationSample,
                 b.m_wristTranslationSample,
                 TuningT::template getTuning<EgocentricWristTranslation<Handedness>>(tuning));
-            return handPoseDistance + wristRotationDistance + wristTranslationDistance;
+            return std::max(handPoseDistance, std::max(wristRotationDistance, wristTranslationDistance));
         }
 
         HandGesture() = default;
@@ -725,7 +725,7 @@ namespace carl::descriptor
                 a.m_relativeSample,
                 b.m_relativeSample,
                 TuningT::template getTuning<EgocentricRelativeWristPosition>(tuning));
-            return leftGestureDistance + rightGestureDistance + relativeWristPositionDistance;
+            return std::max(leftGestureDistance, std::max(rightGestureDistance, relativeWristPositionDistance));
         }
 
         TwoHandGesture() = default;

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -408,7 +408,6 @@ namespace carl::descriptor
         HandShape() = default;
 
     private:
-        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.005, 0.02) };
         static inline constexpr auto calculateDistance{ createDistanceFunction(0.01, 0.03) };
         static inline constexpr NumberT CANONICAL_NORMALIZATION_LENGTH{0.1};
         std::array<trivial::Point, JOINTS.size()> m_positions{};
@@ -488,7 +487,6 @@ namespace carl::descriptor
 
     private:
         static inline constexpr auto calculateDistance{ createDistanceFunction(0.17453, 0.5236) };
-        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.1, 1.0) };
         trivial::Quaternion m_egocentricTemporalOrientation{};
 
         EgocentricWristOrientation(const InputSample& sample, const InputSample&)

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -319,6 +319,7 @@ namespace carl::descriptor
 
     private:
         static inline constexpr auto calculateDistance{ createDistanceFunction(0.005, 0.02) };
+        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.01, 0.03) };
         static inline constexpr NumberT CANONICAL_NORMALIZATION_LENGTH{0.1};
         std::array<trivial::Point, JOINTS.size()> m_positions{};
 
@@ -385,6 +386,7 @@ namespace carl::descriptor
 
     private:
         static inline constexpr auto calculateDistance{ createDistanceFunction(0.17453, 0.5236) };
+        //static inline constexpr auto calculateDistance{ createDistanceFunction(0.1, 1.0) };
         trivial::Quaternion m_egocentricTemporalOrientation{};
 
         EgocentricWristOrientation(const InputSample& sample, const InputSample&)
@@ -559,7 +561,7 @@ namespace carl::descriptor
     private:
         static inline constexpr auto calculateDistance{ createDistanceFunction(0.3, 1.3) };
         // The parameters of the above distance function are based on the assumption of 20fps,
-        // so 20 is used to normalize the data to make the descriptor framerate independent.
+        // so 30 is used to normalize the data to make the descriptor framerate independent.
         static inline constexpr NumberT DISTANCE_PARAMETERS_FRAMES_PER_SECOND{ 30 };
         trivial::Point m_egocentricTemporalPosition{};
 

--- a/CARL/source/DynamicTimeWarping.h
+++ b/CARL/source/DynamicTimeWarping.h
@@ -9,14 +9,17 @@
 
 #include <gsl/span>
 
+#include <array>
+#include <vector>
+
 namespace carl::DynamicTimeWarping
 {
     template <typename VectorT, typename CallableT, typename NumberT = double>
     NumberT Distance(gsl::span<VectorT> a, gsl::span<VectorT> b, CallableT& distance)
     {
-        std::vector<NumberT> priorRow{};
+        thread_local std::vector<NumberT> priorRow{};
+        thread_local std::vector<NumberT> currentRow{};
         priorRow.resize(a.size() + 1);
-        std::vector<NumberT> currentRow{};
         currentRow.resize(priorRow.size());
 
         currentRow[0] = static_cast<NumberT>(0);
@@ -59,9 +62,9 @@ namespace carl::DynamicTimeWarping
         auto& a = longer;
         auto& b = shorter;
 
-        std::vector<NumberT> priorRow{};
+        thread_local std::vector<NumberT> priorRow{};
+        thread_local std::vector<NumberT> currentRow{};
         priorRow.resize(a.size() + 1);
-        std::vector<NumberT> currentRow{};
         currentRow.resize(priorRow.size());
 
         currentRow[0] = static_cast<NumberT>(0);
@@ -103,5 +106,28 @@ namespace carl::DynamicTimeWarping
             }
         }
         return { minimum, minimumIdx };
+    }
+
+    template <typename VectorT, typename CallableT, typename NumberT = double, bool ReverseTime = true>
+    std::tuple<NumberT, size_t> AdaptiveStartInjectiveDistanceAndImageSize(
+        gsl::span<VectorT> longer,
+        gsl::span<VectorT> shorter,
+        CallableT& distance,
+        NumberT minimumImageRatio = 0)
+    {
+        size_t maxAdaptiveStartSize = std::min(longer.size() - shorter.size(), shorter.size() / 2);
+        size_t idx = 0;
+        NumberT score = distance(longer[idx], shorter[0]);
+        for (; idx < maxAdaptiveStartSize; ++idx)
+        {
+            NumberT nextScore = distance(longer[idx + 1], shorter[0]);
+            if (nextScore > score)
+            {
+                break;
+            }
+            score = nextScore;
+        }
+        gsl::span<VectorT> newLonger = gsl::make_span<VectorT>(&longer[idx], longer.size() - idx);
+        return InjectiveDistanceAndImageSize(newLonger, shorter, distance, minimumImageRatio);
     }
 }

--- a/CARL/source/DynamicTimeWarping.h
+++ b/CARL/source/DynamicTimeWarping.h
@@ -67,59 +67,29 @@ namespace carl::DynamicTimeWarping
         priorRow.resize(a.size() + 1);
         currentRow.resize(priorRow.size());
 
-        thread_local std::vector<NumberT> aToADistances{};
-        thread_local std::vector<NumberT> bToADistances{};
-        aToADistances.resize(a.size());
-        bToADistances.resize(a.size());
-
         currentRow[0] = static_cast<NumberT>(0);
         for (size_t idx = 1; idx < priorRow.size(); ++idx)
         {
             currentRow[idx] = std::numeric_limits<NumberT>::max();
         }
 
-        aToADistances[0] = static_cast<NumberT>(0);
-        for (size_t idx = 1; idx < aToADistances.size(); ++idx)
-        {
-            aToADistances[idx] = distance(a[idx - 1], a[idx]);
-        }
-
         for (size_t j = 0; j < b.size(); ++j)
         {
+            priorRow.swap(currentRow);
+            currentRow[0] = std::numeric_limits<NumberT>::max();
+
             for (size_t i = 0; i < a.size(); ++i)
             {
+                NumberT cost{};
                 if constexpr (ReverseTime)
                 {
-                    bToADistances[i] = distance(a[a.size() - i - 1], b[b.size() - j - 1]);
+                    cost = distance(a[a.size() - i - 1], b[b.size() - j - 1]);
                 }
                 else
                 {
-                    bToADistances[i] = distance(a[i], b[j]);
+                    cost = distance(a[i], b[j]);
                 }
-            }
-
-            priorRow.swap(currentRow);
-
-            currentRow[0] = std::numeric_limits<NumberT>::max();
-            for (size_t i = 0; i < a.size(); ++i)
-            {
-                NumberT cost = bToADistances[i];
-                NumberT ssl = bToADistances[i] + (i == 0 ? bToADistances[i] : bToADistances[i - 1]);
-                NumberT bl = aToADistances[i];
-                NumberT scalar{};
-                if (bl < static_cast<NumberT>(0.00001))
-                {
-                    scalar = static_cast<NumberT>(1);
-                }
-                else
-                {
-                    scalar = std::min<NumberT>(std::max<NumberT>(ssl / bl - 1, 0), 1);
-                    if (scalar > 0.1 && scalar < 0.9)
-                    {
-                        scalar = scalar;
-                    }
-                }
-                currentRow[i + 1] = scalar * cost + std::min(priorRow[i], std::min(priorRow[i + 1], currentRow[i]));
+                currentRow[i + 1] = cost + std::min(priorRow[i], std::min(priorRow[i + 1], currentRow[i]));
             }
         }
 

--- a/CARL/source/InputSample.cpp
+++ b/CARL/source/InputSample.cpp
@@ -33,7 +33,7 @@ namespace carl
         serialization << RightHandJointPoses;
     }
 
-    InputSample InputSample::lerp(const InputSample& a, const InputSample& b, double t)
+    InputSample InputSample::Lerp(const InputSample& a, const InputSample& b, double t)
     {
         InputSample result{};
 

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -148,7 +148,8 @@ namespace carl::action
                 using SignalT = Signal<const InputSample&>;
                 arcana::weak_table<SignalT::HandlerT> inputSamplesHandlers{};
                 SignalT inputSampleSignal{ inputSamplesHandlers };
-                typename DescriptorSequence<DescT>::Provider descriptorSequenceProvider{ inputSampleSignal, 2 * m_trimmedSequenceLength };
+                typename DescriptorSequence<DescT>::Provider descriptorSequenceProvider{ inputSampleSignal };
+                descriptorSequenceProvider.supportSequenceOfLength(2 * m_trimmedSequenceLength);
                 Signal<gsl::span<const DescT>>& descriptorSignal{ descriptorSequenceProvider };
 
                 auto samples = recording.getSamples();
@@ -227,7 +228,8 @@ namespace carl::action
                 using SignalT = Signal<const InputSample&>;
                 arcana::weak_table<SignalT::HandlerT> inputSamplesHandlers{};
                 SignalT inputSampleSignal{ inputSamplesHandlers };
-                typename DescriptorSequence<DescriptorT>::Provider descriptorSequenceProvider{ inputSampleSignal, 2 * m_trimmedSequenceLength };
+                typename DescriptorSequence<DescriptorT>::Provider descriptorSequenceProvider{ inputSampleSignal };
+                descriptorSequenceProvider.supportSequenceOfLength(2 * m_trimmedSequenceLength);
                 Signal<gsl::span<const DescriptorT>>& descriptorSignal{ descriptorSequenceProvider };
 
                 auto samples = recording.getSamples();
@@ -325,6 +327,8 @@ namespace carl::action
                 {
                     m_trimmedSequenceLength = std::max(m_trimmedSequenceLength, (5 * ct.size()) / 4);
                 }
+
+                m_sessionImpl.supportSequenceOfLength<DescriptorT>(2 * m_trimmedSequenceLength);
             }
 
             void calculateTuning()

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -484,9 +484,9 @@ namespace carl::action
                 auto& shorter = aLongerThanB ? b : a;
 
                 auto distanceFunction{ [this](const DescriptorT& a, const DescriptorT& b) {
-                  return DescriptorT::Distance(a, b, m_tuning) / DescriptorT::DEFAULT_TUNING.size();
+                  return DescriptorT::Distance(a, b, m_tuning);
                 } };
-                return DynamicTimeWarping::InjectiveDistanceAndImageSize(longer, shorter, distanceFunction, m_minimumImageRatio);
+                return DynamicTimeWarping::AdaptiveStartInjectiveDistanceAndImageSize(longer, shorter, distanceFunction, m_minimumImageRatio);
             }
 
             NumberT calculateNormalizedSequenceDistance(

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -420,7 +420,7 @@ namespace carl::action
             {
                 m_scoringFunction = [this](NumberT distance)
                 {
-                    return std::max(1. - std::pow(distance / (3.16228 * m_sensitivity), 2.) / DescriptorT::DEFAULT_TUNING.size(), 0.);
+                    return std::max(1. - std::pow(distance / (3.16228 * m_sensitivity), 2.), 0.);
                 };
             }
 
@@ -484,7 +484,7 @@ namespace carl::action
                 auto& shorter = aLongerThanB ? b : a;
 
                 auto distanceFunction{ [this](const DescriptorT& a, const DescriptorT& b) {
-                  return DescriptorT::Distance(a, b, m_tuning);
+                  return DescriptorT::Distance(a, b, m_tuning) / DescriptorT::DEFAULT_TUNING.size();
                 } };
                 return DynamicTimeWarping::InjectiveDistanceAndImageSize(longer, shorter, distanceFunction, m_minimumImageRatio);
             }

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -139,46 +139,53 @@ namespace carl::action
             }
 
         protected:
+            // TODO: This has not been reworked or retested sufficiently since paradigms shifted underneath it! The underlying 
+            // logic is probably most still sound, but the implementation needs to be fixed and tested now that samples and 
+            // descriptors can differ in count.
             Example createAutoTrimmedExample(const Recording& recording) const override
             {
+                using DescT = descriptor::TimestampedDescriptor<DescriptorT>;
                 using SignalT = Signal<const InputSample&>;
                 arcana::weak_table<SignalT::HandlerT> inputSamplesHandlers{};
                 SignalT inputSampleSignal{ inputSamplesHandlers };
-                typename DescriptorSequence<DescriptorT>::Provider descriptorSequenceProvider{ inputSampleSignal, 2 * m_trimmedSequenceLength };
-                Signal<gsl::span<const DescriptorT>>& descriptorSignal{ descriptorSequenceProvider };
+                typename DescriptorSequence<DescT>::Provider descriptorSequenceProvider{ inputSampleSignal, 2 * m_trimmedSequenceLength };
+                Signal<gsl::span<const DescT>>& descriptorSignal{ descriptorSequenceProvider };
 
-                auto samples = resample(
-                    recording.getSamples(),
-                    recording.getSamples().front().Timestamp,
-                    recording.getSamples().back().Timestamp,
-                    m_sessionImpl.frameDuration);
+                auto samples = recording.getSamples();
                 size_t idx = 0;
 
                 auto maxScore = std::numeric_limits<NumberT>::lowest();
                 size_t maxScoreIdx = 0;
-                std::vector<DescriptorT> maxScoreTrimmedSequence{};
 
-                using OptionalTicketT = std::optional<typename Signal<gsl::span<const DescriptorT>>::TicketT>;
+                std::vector<DescriptorT> descriptorSequence{};
+                std::vector<DescT> maxScoreTrimmedSequence{};
+
+                using OptionalTicketT = std::optional<typename Signal<gsl::span<const DescT>>::TicketT>;
                 OptionalTicketT maxScoreDescriptorHandlerTicket{ descriptorSignal.addHandler(
-                    [this, &idx, &samples, &maxScore, &maxScoreIdx, &maxScoreTrimmedSequence](gsl::span<const DescriptorT> sequence) {
+                    [this, &idx, &samples, &maxScore, &maxScoreIdx, &maxScoreTrimmedSequence, &descriptorSequence](gsl::span<const DescT> sequence) {
                         if (sequence.size() <= m_trimmedSequenceLength)
                         {
                             return;
                         }
 
-                        auto score = calculateScore(sequence);
+                        descriptorSequence.clear();
+                        for (const auto& element : sequence)
+                        {
+                            descriptorSequence.push_back(element.getUnderlyingDescriptor());
+                        }
+                        auto score = calculateScore(descriptorSequence);
                         if (score > maxScore)
                         {
                             maxScore = score;
                             maxScoreIdx = idx;
 
-                            gsl::span<const DescriptorT> trimmedSequence{
+                            gsl::span<const DescT> trimmedSequence{
                                 &sequence[sequence.size() - m_trimmedSequenceLength], m_trimmedSequenceLength};
 
                             // Note that this logic depends on the fact that descriptors are trivially copyable.
-                            static_assert(std::is_trivially_copyable<DescriptorT>::value);
+                            static_assert(std::is_trivially_copyable<DescT>::value);
                             maxScoreTrimmedSequence.resize(trimmedSequence.size());
-                            std::memcpy(maxScoreTrimmedSequence.data(), trimmedSequence.data(), sizeof(DescriptorT) * trimmedSequence.size());
+                            std::memcpy(maxScoreTrimmedSequence.data(), trimmedSequence.data(), sizeof(DescT) * trimmedSequence.size());
                         }
                     }) };
 
@@ -194,11 +201,18 @@ namespace carl::action
                 auto endT = samples[samples.size() - 1].Timestamp;
                 auto distance = std::numeric_limits<NumberT>::max();
 
+                descriptorSequence.clear();
+                for (const auto& element : maxScoreTrimmedSequence)
+                {
+                    descriptorSequence.push_back(element.getUnderlyingDescriptor());
+                }
+
                 for (const auto& t : m_templates)
                 {
-                    auto [normalizedDistance, imageSize] = calculateSequenceDistance(maxScoreTrimmedSequence, t);
+                    auto [normalizedDistance, imageSize] = calculateSequenceDistance(descriptorSequence, t);
                     if (normalizedDistance < distance)
                     {
+                        // TODO: Rework this to use descriptor timestamps!
                         startT = samples[maxScoreIdx - imageSize].Timestamp;
                         endT = samples[maxScoreIdx].Timestamp;
                         distance = normalizedDistance;
@@ -216,11 +230,7 @@ namespace carl::action
                 typename DescriptorSequence<DescriptorT>::Provider descriptorSequenceProvider{ inputSampleSignal, 2 * m_trimmedSequenceLength };
                 Signal<gsl::span<const DescriptorT>>& descriptorSignal{ descriptorSequenceProvider };
 
-                auto samples = resample(
-                    recording.getSamples(),
-                    recording.getSamples().front().Timestamp,
-                    recording.getSamples().back().Timestamp,
-                    m_sessionImpl.frameDuration);
+                auto samples = recording.getSamples();
                 size_t idx = 0;
 
                 using OptionalTicketT = std::optional<typename Signal<gsl::span<const DescriptorT>>::TicketT>;
@@ -284,8 +294,6 @@ namespace carl::action
                 auto initializeTemplatesFromExamples = [this](gsl::span<const action::Example> examples, std::vector<std::vector<DescriptorT>>& templates) {
                     for (const auto& example : examples)
                     {
-                        //auto samples = resample(example, m_sessionImpl.frameDuration);
-
                         templates.emplace_back();
                         auto& sequence = templates.back();
 
@@ -302,28 +310,6 @@ namespace carl::action
                             descriptor::extendSequence(samples[idx], sequence, mostRecentSample, DescriptorT::DEFAULT_TUNING);
                             ++idx;
                         }
-                        /*sequence.reserve(samples.size() - 1);
-                        if (samples.size() == 1)
-                        {
-                            // For recordings short enough that they only contain one sample, consider them to
-                            // represent a static pose.
-                            auto descriptor = DescriptorT::TryCreate(samples[0], samples[0]);
-                            if (descriptor.has_value())
-                            {
-                                sequence.emplace_back(std::move(descriptor.value()));
-                            }
-                        }
-                        else
-                        {
-                            for (size_t idx = 0; idx < samples.size() - 1; ++idx)
-                            {
-                                auto descriptor = DescriptorT::TryCreate(samples[idx + 1], samples[idx]);
-                                if (descriptor.has_value())
-                                {
-                                    sequence.emplace_back(std::move(descriptor.value()));
-                                }
-                            }
-                        }*/
                     }
                 };
 

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -95,10 +95,10 @@ namespace carl
         m_impl->addInputSample(inputSample);
     }
 
-    arcana::background_dispatcher<128>& Session::processingScheduler()
+    /*arcana::background_dispatcher<128>& Session::processingScheduler()
     {
         return m_impl->processingScheduler();
-    }
+    }*/
 
     arcana::manual_dispatcher<128>& Session::callbackScheduler()
     {

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -37,9 +37,8 @@ namespace carl
         }
     }
 
-    Session::Impl::Impl(size_t samplesPerSecond, size_t maxActionDurationSeconds, bool singleThreaded)
-        : SessionImplBase{ samplesPerSecond * maxActionDurationSeconds }
-        , m_callbackScheduler{ [this](auto&& work) { m_callbackDispatcher(std::forward<std::remove_reference_t<decltype(work)>>(work)); }}
+    Session::Impl::Impl(bool singleThreaded)
+        : m_callbackScheduler{ [this](auto&& work) { m_callbackDispatcher(std::forward<std::remove_reference_t<decltype(work)>>(work)); }}
         , m_processingScheduler{ [this, singleThreaded]() -> SchedulerT {
             if (singleThreaded)
             {
@@ -50,7 +49,6 @@ namespace carl
                 return [this](auto&& work) { m_processingDispatcher(std::forward<std::remove_reference_t<decltype(work)>>(work)); };
             }
         }()}
-        , frameDuration{ 1. / samplesPerSecond }
     {
     }
 
@@ -105,8 +103,8 @@ namespace carl
         // can happen on another thread.
     }
 
-    Session::Session(size_t samplesPerSecond, size_t maxActionDurationSeconds, bool singleThreaded) 
-        : m_impl{ std::make_unique<Impl>(samplesPerSecond, maxActionDurationSeconds, singleThreaded) }
+    Session::Session(bool singleThreaded) 
+        : m_impl{ std::make_unique<Impl>(singleThreaded) }
     {
     }
 

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -7,6 +7,8 @@
 
 #include <carl/Session.h>
 
+#include <arcana/threading/task.h>
+
 #include "SessionImpl.h"
 
 namespace carl
@@ -47,22 +49,34 @@ namespace carl
     {
         // Send inputSample to the resampling logic. Only invoke the signal if the resampler updates the
         // input sequence.
-        appendSampleToResampling(inputSample, m_samples, frameDuration);
-        if (m_samples.size() > 1)
         {
-            SignalHandlersT::apply_to_all([this](auto& callable) {
-                // The argument passed to the handlers here should be the NEW input samples -- only ones they
-                // haven't seen before PLUS the last one they HAVE seen before. This is a tricky and very
-                // tight coupling that exists between the session impl and the descriptor sequence providers,
-                // so it's okay as long as we contain it, but it should still and always be very clearly
-                // commented.
-                // TODO: Consider modifying the signal to make this l-value span unnecessary.
-                gsl::span<const InputSample> span{ m_samples };
-                callable(span);
-            });
+            std::scoped_lock lock{m_samplesMutex};
+            appendSampleToResampling(inputSample, m_samples, frameDuration);
         }
-        m_samples[0] = m_samples.back();
-        m_samples.resize(1);
+        arcana::make_task(processingScheduler(), arcana::cancellation::none(), [this]() {
+            {
+                std::scoped_lock lock{m_samplesMutex};
+                if (m_samples.size() > 1) {
+                    m_processingSamples.swap(m_samples);
+                    m_samples.resize(1);
+                    m_samples[0] = m_processingSamples.back();
+                }
+            }
+
+            if (m_processingSamples.size() > 1)
+            {
+                SignalHandlersT::apply_to_all([this](auto& callable) {
+                    // The argument passed to the handlers here should be the NEW input samples -- only ones they
+                    // haven't seen before PLUS the last one they HAVE seen before. This is a tricky and very
+                    // tight coupling that exists between the session impl and the descriptor sequence providers,
+                    // so it's okay as long as we contain it, but it should still and always be very clearly
+                    // commented.
+                    // TODO: Consider modifying the signal to make this l-value span unnecessary.
+                    gsl::span<const InputSample> span{ m_processingSamples };
+                    callable(span);
+                });
+            }
+        });
 
         // TODO: Later, decouple this so that addInputSample is synchronous and resampling and processing
         // can happen on another thread.
@@ -79,5 +93,20 @@ namespace carl
     void Session::addInput(InputSample inputSample)
     {
         m_impl->addInputSample(inputSample);
+    }
+
+    arcana::background_dispatcher<128>& Session::processingScheduler()
+    {
+        return m_impl->processingScheduler();
+    }
+
+    arcana::manual_dispatcher<128>& Session::callbackScheduler()
+    {
+        return m_impl->callbackScheduler();
+    }
+
+    void Session::tickCallbacks(arcana::cancellation& token)
+    {
+        m_impl->tickCallbacks(token);
     }
 }

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -134,6 +134,11 @@ namespace carl
         m_impl->setLogger(std::move(logger));
     }
 
+    void Session::log(std::string message)
+    {
+        m_impl->log(std::move(message));
+    }
+
     void Session::tickCallbacks(arcana::cancellation& token)
     {
         m_impl->tickCallbacks(token);

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -64,11 +64,8 @@ namespace carl
 
     void Session::Impl::addInputSample(const InputSample& inputSample)
     {
-        // Send inputSample to the resampling logic. Only invoke the signal if the resampler updates the
-        // input sequence.
         {
             std::scoped_lock lock{m_samplesMutex};
-            //appendSampleToResampling(inputSample, m_samples, frameDuration);
             m_samples.push_back(inputSample);
         }
         arcana::make_task(processingScheduler(), arcana::cancellation::none(), [this]() {
@@ -103,9 +100,6 @@ namespace carl
                 }
             }
         });
-
-        // TODO: Later, decouple this so that addInputSample is synchronous and resampling and processing
-        // can happen on another thread.
     }
 
     Session::Session(bool singleThreaded) 

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -42,11 +42,16 @@ namespace carl
         , m_processingScheduler{ [this, singleThreaded]() -> SchedulerT {
             if (singleThreaded)
             {
-                return [this](auto&& work) { arcana::inline_scheduler(std::forward<std::remove_reference_t<decltype(work)>>(work)); };
+                return [](auto&& work) { 
+                    arcana::inline_scheduler(std::forward<std::remove_reference_t<decltype(work)>>(work));
+                };
             }
             else
             {
-                return [this](auto&& work) { m_processingDispatcher(std::forward<std::remove_reference_t<decltype(work)>>(work)); };
+                m_processingDispatcher.emplace();
+                return [&dispatcher = m_processingDispatcher.value()](auto&& work) {
+                    dispatcher(std::forward<std::remove_reference_t<decltype(work)>>(work));
+                };
             }
         }()}
     {

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -12,8 +12,6 @@
 
 #include <arcana/threading/task.h>
 
-#include <iostream>
-
 namespace carl
 {
     namespace

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -17,6 +17,8 @@
 #include <carl/Session.h>
 #include <carl/Signaling.h>
 
+#include <arcana/threading/task.h>
+
 namespace carl
 {
     template<typename DescriptorT, typename = std::enable_if_t<std::is_trivially_copyable_v<DescriptorT>>>
@@ -107,7 +109,7 @@ namespace carl
 
         auto& processingScheduler()
         {
-            return m_processingDispatcher;
+            return arcana::inline_scheduler;// m_processingDispatcher;
         }
 
         auto& callbackScheduler()
@@ -125,12 +127,12 @@ namespace carl
         template <typename DescriptorT>
         auto addHandler(std::function<void(gsl::span<const DescriptorT>)> handler)
         {
-            return static_cast<typename DescriptorSequence<DescriptorT>::Provider*>(this)->addHandler(std::move(handler));
+            return typename DescriptorSequence<DescriptorT>::Provider::addHandler(std::move(handler));
         }
 
     private:
         arcana::manual_dispatcher<128> m_callbackDispatcher{};
-        arcana::background_dispatcher<128> m_processingDispatcher{};
+        //arcana::background_dispatcher<128> m_processingDispatcher{};
         std::vector<InputSample> m_samples{};
         std::vector<InputSample> m_processingSamples{};
         std::mutex m_samplesMutex{};

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -9,14 +9,13 @@
 
 #include "Descriptor.h"
 
-#include <arcana/threading/dispatcher.h>
-
 #include <carl/Example.h>
 #include <carl/InputSample.h>
 #include <carl/Recording.h>
 #include <carl/Session.h>
 #include <carl/Signaling.h>
 
+#include <arcana/threading/dispatcher.h>
 #include <arcana/threading/task.h>
 
 namespace carl
@@ -152,7 +151,7 @@ namespace carl
 
     private:
         arcana::manual_dispatcher<256> m_callbackDispatcher{};
-        arcana::background_dispatcher<256> m_processingDispatcher{};
+        std::optional<arcana::background_dispatcher<256>> m_processingDispatcher{};
         SchedulerT m_callbackScheduler{};
         SchedulerT m_processingScheduler{};
         std::vector<InputSample> m_samples{};

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -143,6 +143,12 @@ namespace carl
             m_logger = std::move(logger);
         }
 
+        void log(std::string message)
+        {
+            std::scoped_lock lock{ m_loggerMutex };
+            m_logger(std::move(message));
+        }
+
     private:
         arcana::manual_dispatcher<256> m_callbackDispatcher{};
         arcana::background_dispatcher<256> m_processingDispatcher{};

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -137,6 +137,12 @@ namespace carl
             return typename DescriptorSequence<DescriptorT>::Provider::addHandler(std::move(handler));
         }
 
+        void setLogger(std::function<void(std::string)> logger)
+        {
+            std::scoped_lock lock{ m_loggerMutex };
+            m_logger = std::move(logger);
+        }
+
     private:
         arcana::manual_dispatcher<256> m_callbackDispatcher{};
         arcana::background_dispatcher<256> m_processingDispatcher{};
@@ -145,5 +151,7 @@ namespace carl
         std::vector<InputSample> m_samples{};
         std::vector<InputSample> m_processingSamples{};
         std::mutex m_samplesMutex{};
+        std::function<void(std::string)> m_logger{};
+        std::mutex m_loggerMutex{};
     };
 }

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -41,14 +41,6 @@ namespace carl
 
             void handleInputSample(const InputSample& sample)
             {
-                /*for (size_t idx = 1; idx < samples.size(); ++idx)
-                {
-                    auto descriptor = DescriptorT::TryCreate(samples[idx], samples[idx - 1]);
-                    if (descriptor.has_value())
-                    {
-                        m_sequence.emplace_back(std::move(descriptor.value()));
-                    }
-                }*/
                 size_t priorSequenceSize = m_sequence.size();
                 descriptor::extendSequence(sample, m_sequence, m_mostRecentSample, DescriptorT::DEFAULT_TUNING);
                 bool descriptorsAdded = m_sequence.size() > priorSequenceSize;

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -134,7 +134,7 @@ namespace carl
         template <typename DescriptorT>
         auto addHandler(std::function<void(gsl::span<const DescriptorT>)> handler)
         {
-            return typename DescriptorSequence<DescriptorT>::Provider::addHandler(std::move(handler));
+            return DescriptorSequence<DescriptorT>::Provider::addHandler(std::move(handler));
         }
 
         void setLogger(std::function<void(std::string)> logger)

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -9,6 +9,8 @@
 
 #include "Descriptor.h"
 
+#include <arcana/threading/dispatcher.h>
+
 #include <carl/Example.h>
 #include <carl/InputSample.h>
 #include <carl/Recording.h>
@@ -103,6 +105,21 @@ namespace carl
 
         void addInputSample(const InputSample& inputSample);
 
+        auto& processingScheduler()
+        {
+            return m_processingDispatcher;
+        }
+
+        auto& callbackScheduler()
+        {
+            return m_callbackDispatcher;
+        }
+
+        void tickCallbacks(arcana::cancellation& token)
+        {
+            m_callbackDispatcher.tick(token);
+        }
+
         const double frameDuration{};
 
         template <typename DescriptorT>
@@ -112,6 +129,10 @@ namespace carl
         }
 
     private:
+        arcana::manual_dispatcher<128> m_callbackDispatcher{};
+        arcana::background_dispatcher<128> m_processingDispatcher{};
         std::vector<InputSample> m_samples{};
+        std::vector<InputSample> m_processingSamples{};
+        std::mutex m_samplesMutex{};
     };
 }

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -108,7 +108,7 @@ namespace carl
         descriptor::TwoHandGesture>
     {
     public:
-        Impl(size_t samplesPerSecond = 20, size_t maxActionDurationSeconds = 5);
+        Impl(size_t samplesPerSecond, size_t maxActionDurationSeconds, bool singleThreaded);
 
         static Session::Impl& getFromSession(Session& session);
 
@@ -116,12 +116,12 @@ namespace carl
 
         auto& processingScheduler()
         {
-            return m_processingDispatcher;
+            return m_processingScheduler;
         }
 
         auto& callbackScheduler()
         {
-            return m_callbackDispatcher;
+            return m_callbackScheduler;
         }
 
         void tickCallbacks(arcana::cancellation& token)
@@ -138,8 +138,10 @@ namespace carl
         }
 
     private:
-        arcana::manual_dispatcher<128> m_callbackDispatcher{};
-        arcana::background_dispatcher<128> m_processingDispatcher{};
+        arcana::manual_dispatcher<256> m_callbackDispatcher{};
+        arcana::background_dispatcher<256> m_processingDispatcher{};
+        SchedulerT m_callbackScheduler{};
+        SchedulerT m_processingScheduler{};
         std::vector<InputSample> m_samples{};
         std::vector<InputSample> m_processingSamples{};
         std::mutex m_samplesMutex{};

--- a/Targets/CMakeLists.txt
+++ b/Targets/CMakeLists.txt
@@ -3,12 +3,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+if(ANDROID)
+    find_library(android_logging log)
+endif()
+
 add_library(carl_static_library "c_api/main.cpp")
 target_link_libraries(carl_static_library PUBLIC carl_core)
 if(EMSCRIPTEN)
     target_link_options(carl_static_library PUBLIC -s EXPORTED_FUNCTIONS=["_getBytes","_startRecording","_recordInputSample","_finishRecording","_serializeRecording","_deserializeRecording","_disposeRecording","_getRecordingInspector","_inspect","_getStartTimestamp","_getEndTimestamp","_disposeRecordingInspector","_createdDefinition","_addExample","_getDefaultSensitivity","_setDefaultSensitivity","_serializeDefinition","_deserializeDefinition","_getExamplesCount","_getRecordingFromExampleAtIdx","_getStartTimestampFromExampleAtIdx","_getEndTimestampFromExampleAtIdx","_disposeDefinition","_createSession","_addInputSample","_disposeSession","_createRecognizer","_getCurrentScore","_setSensitivity","_getCanonicalRecordingInspector","_disposeRecognizer","_malloc","_free"])
 elseif(WIN32 OR WINDOWS_STORE)
     target_compile_definitions(carl_static_library PRIVATE CARL_PLATFORM_WINDOWS)
+elseif(ANDROID)
+    target_compile_definitions(carl_static_library PRIVATE CARL_PLATFORM_ANDROID)
+    target_link_libraries(carl_static_library PRIVATE ${android_logging})
 endif()
 set_property(TARGET carl_static_library PROPERTY FOLDER "Targets")
 
@@ -18,8 +25,9 @@ if(NOT EMSCRIPTEN)
     set_property(TARGET carl_shared_library PROPERTY FOLDER "Targets")
     if(WIN32 OR WINDOWS_STORE)
         target_compile_definitions(carl_shared_library PRIVATE CARL_PLATFORM_WINDOWS)
-    endif()
-    if(ANDROID)
+    elseif(ANDROID)
+        target_compile_definitions(carl_shared_library PRIVATE CARL_PLATFORM_ANDROID)
+        target_link_libraries(carl_shared_library PRIVATE ${android_logging})
         set_property(TARGET carl_shared_library PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
 endif()

--- a/Targets/CMakeLists.txt
+++ b/Targets/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(carl_static_library "c_api/main.cpp")
 target_link_libraries(carl_static_library PUBLIC carl_core)
 if(EMSCRIPTEN)
     target_link_options(carl_static_library PUBLIC -s EXPORTED_FUNCTIONS=["_getBytes","_startRecording","_recordInputSample","_finishRecording","_serializeRecording","_deserializeRecording","_disposeRecording","_getRecordingInspector","_inspect","_getStartTimestamp","_getEndTimestamp","_disposeRecordingInspector","_createdDefinition","_addExample","_getDefaultSensitivity","_setDefaultSensitivity","_serializeDefinition","_deserializeDefinition","_getExamplesCount","_getRecordingFromExampleAtIdx","_getStartTimestampFromExampleAtIdx","_getEndTimestampFromExampleAtIdx","_disposeDefinition","_createSession","_addInputSample","_disposeSession","_createRecognizer","_getCurrentScore","_setSensitivity","_getCanonicalRecordingInspector","_disposeRecognizer","_malloc","_free"])
+elseif(WIN32 OR WINDOWS_STORE)
+    target_compile_definitions(carl_static_library PRIVATE CARL_PLATFORM_WINDOWS)
 endif()
 set_property(TARGET carl_static_library PROPERTY FOLDER "Targets")
 

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -50,6 +50,7 @@ extern "C"
     C_API_EXPORT(uint64_t) getCounterexampleAtIdx(uint64_t definitionPtr, uint64_t idx);
     C_API_EXPORT(void) disposeDefinition(uint64_t definitionPtr);
     C_API_EXPORT(uint64_t) createSession();
+    C_API_EXPORT(uint64_t) createSingleThreadedSession();
     C_API_EXPORT(void) tickCallbacks(uint64_t sessionPtr);
     C_API_EXPORT(void) addInputSample(uint64_t sessionPtr, uint8_t* bytes, uint64_t size);
     C_API_EXPORT(void) disposeSession(uint64_t sessionPtr);
@@ -281,6 +282,12 @@ void disposeDefinition(uint64_t definitionPtr)
 uint64_t createSession()
 {
     auto* ptr = new carl::Session();
+    return reinterpret_cast<uint64_t>(ptr);
+}
+
+uint64_t createSingleThreadedSession()
+{
+    auto* ptr = new carl::Session(20, 5, true);
     return reinterpret_cast<uint64_t>(ptr);
 }
 

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -14,7 +14,7 @@
 #define C_API_CALLBACK(ReturnT) ReturnT __stdcall
 #else
 #define C_API_EXPORT(ReturnT) ReturnT
-#define C_API_CALLBACK(ReturnT) ReturnT
+#define C_API_CALLBACK(ReturnT) ReturnT __attribute__((stdcall))
 #endif
 
 extern "C"
@@ -51,6 +51,7 @@ extern "C"
     C_API_EXPORT(void) disposeDefinition(uint64_t definitionPtr);
     C_API_EXPORT(uint64_t) createSession();
     C_API_EXPORT(uint64_t) createSingleThreadedSession();
+    C_API_EXPORT(void) setSessionLogger(uint64_t sessionPtr, C_API_CALLBACK(void) callback(const char*));
     C_API_EXPORT(void) tickCallbacks(uint64_t sessionPtr);
     C_API_EXPORT(void) addInputSample(uint64_t sessionPtr, uint8_t* bytes, uint64_t size);
     C_API_EXPORT(void) disposeSession(uint64_t sessionPtr);
@@ -289,6 +290,14 @@ uint64_t createSingleThreadedSession()
 {
     auto* ptr = new carl::Session(20, 5, true);
     return reinterpret_cast<uint64_t>(ptr);
+}
+
+void setSessionLogger(uint64_t sessionPtr, C_API_CALLBACK(void) callback(const char*))
+{
+    auto& session = *reinterpret_cast<carl::Session*>(sessionPtr);
+    session.setLogger([callback](std::string message) {
+        callback(message.c_str());
+    });
 }
 
 void tickCallbacks(uint64_t sessionPtr)

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -309,7 +309,7 @@ uint64_t createSession()
 
 uint64_t createSingleThreadedSession()
 {
-    auto* ptr = new carl::Session(20, 5, true);
+    auto* ptr = new carl::Session(true);
     setUpSession(*ptr);
     return reinterpret_cast<uint64_t>(ptr);
 }

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -14,7 +14,7 @@
 #define C_API_CALLBACK(ReturnT) ReturnT __stdcall
 #else
 #define C_API_EXPORT(ReturnT) ReturnT
-#define C_API_CALLBACK(ReturnT) ReturnT __attribute__((stdcall))
+#define C_API_CALLBACK(ReturnT) ReturnT
 #endif
 
 extern "C"
@@ -60,6 +60,7 @@ extern "C"
     C_API_EXPORT(void) setSensitivity(uint64_t recognizerPtr, double sensitivity);
     C_API_EXPORT(uint64_t) getCanonicalRecordingInspector(uint64_t recognizerPtr);
     C_API_EXPORT(void) disposeRecognizer(uint64_t sessionPtr, uint64_t recognizerPtr);
+    C_API_EXPORT(void) testAsyncExceptionBehavior(uint64_t sessionPtr);
 }
 
 uint64_t getBytes(uint64_t bytesPtr, uint8_t* destination, uint64_t size)
@@ -353,5 +354,13 @@ void disposeRecognizer(uint64_t sessionPtr, uint64_t recognizerPtr)
     auto& session = *reinterpret_cast<carl::Session*>(sessionPtr);
     arcana::make_task(session.processingScheduler(), arcana::cancellation::none(), [recognizerPtr]() {
         delete reinterpret_cast<carl::action::Recognizer*>(recognizerPtr);
+    });
+}
+
+void testAsyncExceptionBehavior(uint64_t sessionPtr)
+{
+    auto& session = *reinterpret_cast<carl::Session*>(sessionPtr);
+    session.processingScheduler()([]() {
+        throw std::runtime_error{ "Test async exception behavior" };
     });
 }

--- a/Targets/console/main.cpp
+++ b/Targets/console/main.cpp
@@ -117,7 +117,7 @@ void test2()
     for (; recording.getSamples()[idx + 1].Timestamp < recording.getInspector().endTimestamp(); ++idx);
     auto sample = recording.getSamples()[idx];
 
-    carl::Session session{ 20, 5, true };
+    carl::Session session{ true };
     carl::action::Recognizer recognizer{ session, definition };
     for (const auto& sample : recording.getSamples())
     {

--- a/Targets/console/main.cpp
+++ b/Targets/console/main.cpp
@@ -166,6 +166,6 @@ void main()
     */
 
     //test();
-    test2();
-    //test3();
+    //test2();
+    test3();
 }

--- a/Targets/console/main.cpp
+++ b/Targets/console/main.cpp
@@ -134,23 +134,39 @@ void test2()
 
 void test3()
 {
-    auto definition = loadDefinition("C:\\scratch\\CARLFiles\\push_recordings\\definition_2.bin");
-    auto example0 = loadExample("C:\\scratch\\CARLFiles\\push_recordings\\recording_0.bin");
-    auto example1 = loadExample("C:\\scratch\\CARLFiles\\push_recordings\\recording_1.bin");
-    auto example2 = loadExample("C:\\scratch\\CARLFiles\\push_recordings\\recording_2.bin");
+    //auto definition = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\pullDefinition.bytes");
+    auto definition0 = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\definition_0.bin");
+    auto example0 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_0.bin");
+    auto example1 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_1.bin");
+    auto example2 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_2.bin");
 
     //carl::action::Definition definition{ carl::action::Definition::ActionType::RightHandGesture };
     //definition.addExample(example0);
 
     carl::Session session{};
     
-    carl::action::Recognizer recognizer{ session, definition };
+    carl::action::Recognizer recognizer{ session, definition0 };
 
+    recognizer.analyzeRecording(example0.getRecording(), std::cout);
+    std::cout << std::endl;
+    recognizer.analyzeRecording(example1.getRecording(), std::cout);
+    std::cout << std::endl;
     recognizer.analyzeRecording(example2.getRecording(), std::cout);
+    std::cout << std::endl;
 }
 
 void main()
 {
+    /*
+    Tuning profile: Let the user provide a set of definitions (all of which contain examples) as 
+    well as independent examples. The definitions (obviously) represent their own action, and the 
+    independent examples represent no action. The system then analyzes every example against 
+    every other example, determining the expected distances across descriptor dimensions, trying 
+    to arrive at an optimal tuning.
+    
+    Instead of DTW, do a naive sequence match? Fail out if any single connection is too large?
+    */
+
     //test();
     //test2();
     test3();

--- a/Targets/console/main.cpp
+++ b/Targets/console/main.cpp
@@ -117,7 +117,7 @@ void test2()
     for (; recording.getSamples()[idx + 1].Timestamp < recording.getInspector().endTimestamp(); ++idx);
     auto sample = recording.getSamples()[idx];
 
-    carl::Session session{};
+    carl::Session session{ 20, 5, true };
     carl::action::Recognizer recognizer{ session, definition };
     for (const auto& sample : recording.getSamples())
     {
@@ -127,6 +127,7 @@ void test2()
         {
             std::cout << "Aha!" << std::endl;
         }
+        session.tickCallbacks(arcana::cancellation::none());
     }
 }
 
@@ -166,6 +167,6 @@ void main()
     */
 
     //test();
-    //test2();
-    test3();
+    test2();
+    //test3();
 }

--- a/Targets/console/main.cpp
+++ b/Targets/console/main.cpp
@@ -110,8 +110,8 @@ void test()
 
 void test2()
 {
-    auto definition = loadDefinition("C:\\scratch\\CARLFiles\\definition_2.bin");
-    auto recording = definition.getExamples().front().getRecording();
+    auto definition = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\pullDefinition.bytes");
+    auto recording = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_2.bin").getRecording();
 
     int idx = 0;
     for (; recording.getSamples()[idx + 1].Timestamp < recording.getInspector().endTimestamp(); ++idx);
@@ -119,23 +119,21 @@ void test2()
 
     carl::Session session{};
     carl::action::Recognizer recognizer{ session, definition };
-    for (idx = 0; idx < 1000; ++idx)
+    for (const auto& sample : recording.getSamples())
     {
-        if (idx == 900)
+        session.addInput(sample);
+        std::cout << recognizer.currentScore() << std::endl;
+        if (recognizer.currentScore() > 0.01)
         {
-            std::cout << "Ready to test" << std::endl;
+            std::cout << "Aha!" << std::endl;
         }
-
-        auto newSample{ sample };
-        newSample.Timestamp = idx * 0.05;
-        session.addInput(newSample);
     }
 }
 
 void test3()
 {
-    //auto definition = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\pullDefinition.bytes");
-    auto definition0 = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\definition_0.bin");
+    auto definition = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\pullDefinition.bytes");
+    //auto definition = loadDefinition("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\definition_0.bin");
     auto example0 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_0.bin");
     auto example1 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_1.bin");
     auto example2 = loadExample("C:\\scratch\\CARLFiles\\pull_recordings\\newRecordings\\recording_2.bin");
@@ -145,12 +143,12 @@ void test3()
 
     carl::Session session{};
     
-    carl::action::Recognizer recognizer{ session, definition0 };
+    carl::action::Recognizer recognizer{ session, definition };
 
-    recognizer.analyzeRecording(example0.getRecording(), std::cout);
-    std::cout << std::endl;
-    recognizer.analyzeRecording(example1.getRecording(), std::cout);
-    std::cout << std::endl;
+    //recognizer.analyzeRecording(example0.getRecording(), std::cout);
+    //std::cout << std::endl;
+    //recognizer.analyzeRecording(example1.getRecording(), std::cout);
+    //std::cout << std::endl;
     recognizer.analyzeRecording(example2.getRecording(), std::cout);
     std::cout << std::endl;
 }
@@ -168,6 +166,6 @@ void main()
     */
 
     //test();
-    //test2();
-    test3();
+    test2();
+    //test3();
 }


### PR DESCRIPTION
Brings in asynchrony (i.e., running recognition on a background thread) as well as distance-based resampling (instead of time-based resampling) and a switch to using dimensional maximality instead of summation when computing the distance between high-dimensional descriptors. These are more changes than are ideal for a single PR, but the precipitating workstreams were all done interleaved (and often begun as mechanisms for evaluating/debugging each other).