### PR TITLE
Distance and scoring adjustments

### DIFF
--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -118,7 +118,7 @@ namespace carl::action
                 : Recognizer::Impl{ session, sensitivity }
                 , m_ticket{ Session::Impl::getFromSession(session).addHandler<DescriptorT>(
                     [this](gsl::span<const DescriptorT> sequence) { handleSequence(sequence); }) }
-            , m_distanceFunction{ [this](const auto& a, const auto& b) { return DescriptorT::Distance(a, b, m_tuning); } }
+                , m_distanceFunction{ [this](const auto& a, const auto& b) { return DescriptorT::Distance(a, b, m_tuning); } }
             {
                 m_tuning = DescriptorT::DEFAULT_TUNING;
                 initializeTemplates(examples, counterexamples);
@@ -262,9 +262,10 @@ namespace carl::action
             void createUnitScoringFunction()
             {
                 m_scoringFunction = [this](NumberT distance)
-                    {
-                        return std::max(1. - std::pow(distance / (3.16228 * m_sensitivity), 2.), 0.);
-                    };
+                {
+                    distance /= DescriptorT::DEFAULT_TUNING.size();
+                    return std::max(1. - std::pow(distance / (3.16228 * m_sensitivity), 2.), 0.);
+                };
             }
 
             void createScoringFunction()

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -169,7 +169,7 @@ namespace carl::action
 
             void analyzeRecording(const Recording& recording, std::ostream& output) const override
             {
-                using SignalT = Signal<const InputSample&>;
+                using SignalT = Signal<gsl::span<const InputSample>>;
                 arcana::weak_table<SignalT::HandlerT> inputSamplesHandlers{};
                 SignalT inputSampleSignal{ inputSamplesHandlers };
                 typename DescriptorSequence<DescriptorT>::Provider descriptorSequenceProvider{ inputSampleSignal };
@@ -219,7 +219,8 @@ namespace carl::action
                 for (; idx < samples.size(); ++idx)
                 {
                     auto& sample = samples[idx];
-                    inputSamplesHandlers.apply_to_all([&sample](auto& callable) mutable { callable(sample); });
+                    gsl::span<const InputSample> span{ &sample, 1 };
+                    inputSamplesHandlers.apply_to_all([span](auto& callable) mutable { callable(span); });
                 }
 
                 maxScoreDescriptorHandlerTicket.reset();

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -76,12 +76,10 @@ namespace carl
                 }
             }
 
-            for (const InputSample& sample : m_processingSamples)
-            {
-                SignalHandlersT::apply_to_all([this, &sample](auto& callable) {
-                    callable(sample);
-                });
-            }
+            gsl::span<const InputSample> span{ m_processingSamples };
+            SignalHandlersT::apply_to_all([span](auto& callable) mutable {
+                callable(span);
+            });
         }).then(arcana::inline_scheduler, arcana::cancellation::none(), [this](arcana::expected<void, std::exception_ptr> expected) {
             if (expected.has_error())
             {


### PR DESCRIPTION
Switched back from a maximal-dimension distance function to an aggregated approach, with normalization for scoring. This had been the approach earlier in development and is believed logically to be preferable (with correct tuning), but was swapped for maximality earlier in development before difference-based resampling was introduced as maximality appeared to yield better results at the time.

Also added a few optimizations, including the ability to drop samples when necessary to keep up and an initial, rudimentary early-out mechanism to limit the frequency of expensive comparisons.