### PR TITLE
Modified example expansion strategy

### DIFF
--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -397,7 +397,7 @@ namespace carl::descriptor
                         // intermediate sample is too distant, continue searching for a nearer sample
                         upper = mid;
                     }
-                    else if (distance < NumberT{ 0.9 } *THRESHOLD)
+                    else if (distance < NumberT{ 0.9 } * THRESHOLD)
                     {
                         // intermediate sample is too close, continue searching for a more distant sample
                         lower = mid;


### PR DESCRIPTION
Modified example expansion strategy to split by sample rather than by time, removing the tendency of time splitting to have unintended motion in pose definitions.