### PR TITLE
True controller support and robustification

### DIFF
--- a/CARL/include/carl/Definition.h
+++ b/CARL/include/carl/Definition.h
@@ -31,6 +31,8 @@ namespace carl::action
             LeftControllerGesture = 5,
             RightControllerGesture = 6,
             TwoControllerGesture = 7,
+            LeftWristTrajectory = 8,
+            RightWristTrajectory = 9,
         };
 
         Definition(ActionType actionType);

--- a/CARL/include/carl/Session.h
+++ b/CARL/include/carl/Session.h
@@ -26,7 +26,7 @@ namespace carl
         Session(bool singleThreaded = false);
         ~Session();
 
-        void addInput(InputSample);
+        void addInput(const InputSample&);
 
         SchedulerT& callbackScheduler();
         SchedulerT& processingScheduler();

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -531,7 +531,7 @@ namespace carl::descriptor
             auto tuning = DEFAULT_TUNING;
             for (size_t idx = 0; idx < tuning.size(); ++idx)
             {
-                NumberT maxConnectionCost = 0;
+                NumberT maxAverageConnectionCost = 0;
                 for (const auto& extendedSequence : extendedSequences)
                 {
                     for (const auto& sequence : sequences)
@@ -540,10 +540,10 @@ namespace carl::descriptor
                             return InternalRawDistance(idx, a, b);
                         };
                         auto result = DynamicTimeWarping::Match<const HandShape<Handedness>>(extendedSequence, sequence, distanceFunction);
-                        maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                        maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                     }
                 }
-                tuning[idx] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[idx]);
+                tuning[idx] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[idx]);
             }
             return tuning;
         }
@@ -678,7 +678,7 @@ namespace carl::descriptor
             auto extendedSequences = createDescriptorSequencesFromExamples<EgocentricWristOrientation<Handedness>>(examples, DEFAULT_TUNING, 1.);
 
             auto tuning = DEFAULT_TUNING;
-            NumberT maxConnectionCost = 0;
+            NumberT maxAverageConnectionCost = 0;
             for (const auto& extendedSequence : extendedSequences)
             {
                 for (const auto& sequence : sequences)
@@ -687,10 +687,10 @@ namespace carl::descriptor
                         return InternalRawDistance(a, b);
                     };
                     auto result = DynamicTimeWarping::Match<const EgocentricWristOrientation<Handedness>>(extendedSequence, sequence, distanceFunction);
-                    maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                    maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                 }
             }
-            tuning[0] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
+            tuning[0] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
             return tuning;
         }
 
@@ -813,7 +813,7 @@ namespace carl::descriptor
             auto extendedSequences = createDescriptorSequencesFromExamples<WristRotation<Handedness>>(examples, DEFAULT_TUNING, 1.);
 
             auto tuning = DEFAULT_TUNING;
-            NumberT maxConnectionCost = 0;
+            NumberT maxAverageConnectionCost = 0;
             for (const auto& extendedSequence : extendedSequences)
             {
                 for (const auto& sequence : sequences)
@@ -822,10 +822,10 @@ namespace carl::descriptor
                         return InternalRawDistance(a, b);
                     };
                     auto result = DynamicTimeWarping::Match<const WristRotation<Handedness>>(extendedSequence, sequence, distanceFunction);
-                    maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                    maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                 }
             }
-            tuning[0] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
+            tuning[0] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
             return tuning;
         }
 
@@ -950,7 +950,7 @@ namespace carl::descriptor
             auto extendedSequences = createDescriptorSequencesFromExamples<EgocentricWristTranslation<Handedness>>(examples, DEFAULT_TUNING, 1.);
 
             auto tuning = DEFAULT_TUNING;
-            NumberT maxConnectionCost = 0;
+            NumberT maxAverageConnectionCost = 0;
             for (const auto& extendedSequence : extendedSequences)
             {
                 for (const auto& sequence : sequences)
@@ -959,10 +959,10 @@ namespace carl::descriptor
                         return InternalRawDistance(a, b);
                     };
                     auto result = DynamicTimeWarping::Match<const EgocentricWristTranslation<Handedness>>(extendedSequence, sequence, distanceFunction);
-                    maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                    maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                 }
             }
-            tuning[0] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
+            tuning[0] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
             return tuning;
         }
 
@@ -1088,7 +1088,7 @@ namespace carl::descriptor
             auto extendedSequences = createDescriptorSequencesFromExamples<EgocentricWristDisplacement<Handedness>>(examples, DEFAULT_TUNING, 1.);
 
             auto tuning = DEFAULT_TUNING;
-            NumberT maxConnectionCost = 0;
+            NumberT maxAverageConnectionCost = 0;
             for (const auto& extendedSequence : extendedSequences)
             {
                 for (const auto& sequence : sequences)
@@ -1097,10 +1097,10 @@ namespace carl::descriptor
                         return InternalRawDistance(a, a0, b, b0);
                     };
                     auto result = DynamicTimeWarping::Match<const EgocentricWristDisplacement<Handedness>>(extendedSequence, sequence, distanceFunction);
-                    maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                    maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                 }
             }
-            tuning[0] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
+            tuning[0] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
             return tuning;
         }
 
@@ -1222,7 +1222,7 @@ namespace carl::descriptor
             auto extendedSequences = createDescriptorSequencesFromExamples<EgocentricRelativeWristPosition>(examples, DEFAULT_TUNING, 1.);
 
             auto tuning = DEFAULT_TUNING;
-            NumberT maxConnectionCost = 0;
+            NumberT maxAverageConnectionCost = 0;
             for (const auto& extendedSequence : extendedSequences)
             {
                 for (const auto& sequence : sequences)
@@ -1231,10 +1231,10 @@ namespace carl::descriptor
                         return InternalRawDistance(a, b);
                     };
                     auto result = DynamicTimeWarping::Match<const EgocentricRelativeWristPosition>(extendedSequence, sequence, distanceFunction);
-                    maxConnectionCost = std::max<NumberT>(result.MaxConnectionCost, maxConnectionCost);
+                    maxAverageConnectionCost = std::max<NumberT>(result.MaxConnectionCost / result.Connections, maxAverageConnectionCost);
                 }
             }
-            tuning[0] = std::max(maxConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
+            tuning[0] = std::max(maxAverageConnectionCost / IDENTICALITY_THRESHOLD, DEFAULT_TUNING[0]);
             return tuning;
         }
 

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -463,7 +463,7 @@ namespace carl::descriptor
 
     class TimePoint
     {
-        static constexpr char* ANALYSIS_DIMENSION_NAME = "TimePoint";
+        static inline constexpr const char* ANALYSIS_DIMENSION_NAME = "TimePoint";
 
     public:
         static constexpr std::array<NumberT, 1> DEFAULT_TUNING{ 1. };

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -531,14 +531,14 @@ namespace carl::descriptor
                 }
                 };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const TimePoint, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const TimePoint, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
         TimePoint() = default;
 
     private:
-        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.2 };
+        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.1 };
         static inline constexpr auto normalizeDistance{ createDistanceNormalizationFunction(IDENTICALITY_THRESHOLD) };
         NumberT m_timestamp{};
 
@@ -679,7 +679,7 @@ namespace carl::descriptor
                     }
                 };
                 auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-                DynamicTimeWarping::Match<const HandShape<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+                DynamicTimeWarping::Match<const HandShape<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             }
             return results;
         }
@@ -823,7 +823,7 @@ namespace carl::descriptor
                 }
             };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const EgocentricWristOrientation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const EgocentricWristOrientation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
@@ -958,7 +958,7 @@ namespace carl::descriptor
                 }
             };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const WristRotation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const WristRotation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
@@ -1095,7 +1095,7 @@ namespace carl::descriptor
                 }
             };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const EgocentricWristTranslation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const EgocentricWristTranslation<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
@@ -1233,14 +1233,14 @@ namespace carl::descriptor
                 }
             };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const EgocentricWristDisplacement<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const EgocentricWristDisplacement<Handedness>, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
         EgocentricWristDisplacement() = default;
 
     private:
-        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.06 };
+        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.02 };
         static inline constexpr auto normalizeDistance{ createDistanceNormalizationFunction(IDENTICALITY_THRESHOLD) };
         trivial::Point m_position{};
         trivial::Transform m_inverseEts{};
@@ -1367,7 +1367,7 @@ namespace carl::descriptor
                 }
             };
             auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-            DynamicTimeWarping::Match<const EgocentricRelativeWristPosition, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+            DynamicTimeWarping::Match<const EgocentricRelativeWristPosition, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
             return results;
         }
 
@@ -1462,7 +1462,7 @@ namespace carl::descriptor
                     return Distance(a, a0, b, b0, tuning);
                 };
                 auto rowsCallback = [&rows](std::vector<DynamicTimeWarping::MatchResult<NumberT>> row) { rows.push_back(std::move(row)); };
-                DynamicTimeWarping::Match<const CombinedDescriptor, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, rowsCallback);
+                DynamicTimeWarping::Match<const CombinedDescriptor, decltype(distanceFunction), NumberT, true, decltype(rowsCallback)>(target, query, distanceFunction, 0, rowsCallback);
                 return arrayConcat(underlyingAnalysis, results);
             }
             else

--- a/CARL/source/Descriptor.h
+++ b/CARL/source/Descriptor.h
@@ -687,7 +687,7 @@ namespace carl::descriptor
         HandShape() = default;
 
     private:
-        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.01 };
+        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.005 };
         static inline constexpr auto normalizeDistance{ createDistanceNormalizationFunction(IDENTICALITY_THRESHOLD) };
         static inline constexpr NumberT CANONICAL_NORMALIZATION_LENGTH{ 0.1 };
         std::array<trivial::Point, JOINTS.size()> m_positions{};
@@ -1374,7 +1374,7 @@ namespace carl::descriptor
         EgocentricRelativeWristPosition() = default;
 
     private:
-        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.06 };
+        static inline constexpr NumberT IDENTICALITY_THRESHOLD{ 0.02 };
         static inline constexpr auto normalizeDistance{ createDistanceNormalizationFunction(IDENTICALITY_THRESHOLD) };
         trivial::Point m_egocentricRelativeWristPosition{};
 
@@ -1678,12 +1678,15 @@ namespace carl::descriptor
     using HandPose = CombinedDescriptorT<HandShape<Handedness>, EgocentricWristOrientation<Handedness>>;
 
     template<Handedness Handedness>
-    using HandGesture = CombinedDescriptorT<TimePoint, HandPose<Handedness>, WristRotation<Handedness>, EgocentricWristTranslation<Handedness>, EgocentricWristDisplacement<Handedness>>;
-
-    using TwoHandGesture = CombinedDescriptorT<TimePoint, HandGesture<Handedness::LeftHanded>, HandGesture<Handedness::RightHanded>, EgocentricRelativeWristPosition>;
+    using WristTrajectory = CombinedDescriptorT<TimePoint, EgocentricWristDisplacement<Handedness>>;
 
     template<Handedness Handedness>
-    using ControllerGesture = CombinedDescriptorT<TimePoint, EgocentricWristOrientation<Handedness>, WristRotation<Handedness>, EgocentricWristTranslation<Handedness>, EgocentricWristDisplacement<Handedness>>;
+    using HandGesture = CombinedDescriptorT<HandPose<Handedness>, WristTrajectory<Handedness>, WristRotation<Handedness>, EgocentricWristTranslation<Handedness>>;
 
-    using TwoControllerGesture = CombinedDescriptorT<TimePoint, ControllerGesture<Handedness::LeftHanded>, ControllerGesture<Handedness::RightHanded>, EgocentricRelativeWristPosition>;
+    using TwoHandGesture = CombinedDescriptorT<HandGesture<Handedness::LeftHanded>, HandGesture<Handedness::RightHanded>, EgocentricRelativeWristPosition>;
+
+    template<Handedness Handedness>
+    using ControllerGesture = CombinedDescriptorT<WristTrajectory<Handedness>, EgocentricWristOrientation<Handedness>, WristRotation<Handedness>, EgocentricWristTranslation<Handedness>>;
+
+    using TwoControllerGesture = CombinedDescriptorT<ControllerGesture<Handedness::LeftHanded>, ControllerGesture<Handedness::RightHanded>, EgocentricRelativeWristPosition>;
 }

--- a/CARL/source/DynamicTimeWarping.h
+++ b/CARL/source/DynamicTimeWarping.h
@@ -161,7 +161,7 @@ namespace carl::DynamicTimeWarping
     };
 
     template <typename VectorT, typename CallableT, typename NumberT = double, bool ReturnAllResults = false, typename... Ts>
-    MatchResult<NumberT> Match(gsl::span<VectorT> target, gsl::span<VectorT> query, CallableT& distance, Ts&... ts)
+    MatchResult<NumberT> Match(gsl::span<VectorT> target, gsl::span<VectorT> query, CallableT& distance, size_t minimumImageIdx = 0, Ts&... ts)
     {
         struct Entry
         {
@@ -251,8 +251,8 @@ namespace carl::DynamicTimeWarping
         }
 
         NumberT matchCost = std::numeric_limits<NumberT>::max();
-        size_t matchIdx = 0;
-        for (size_t idx = 0; idx < currentRow.size(); ++idx)
+        size_t matchIdx = minimumImageIdx;
+        for (size_t idx = minimumImageIdx; idx < currentRow.size(); ++idx)
         {
             if (currentRow[idx].Cost < matchCost)
             {

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -141,7 +141,7 @@ namespace carl::action
             RecognizerImpl(Session& session, gsl::span<const action::Example> examples, gsl::span<const action::Example> counterexamples, NumberT sensitivity)
                 : Recognizer::Impl{ session, sensitivity }
                 , m_ticket{ Session::Impl::getFromSession(session).addHandler<DescriptorT>(
-                    [this](gsl::span<const DescriptorT> sequence) { handleSequence(sequence); }) }
+                    [this](gsl::span<const DescriptorT> sequence, size_t newDescriptorsCount) { handleSequence(sequence, newDescriptorsCount); }) }
                 , m_distanceFunction{ [this](const auto& a, const auto& a0, const auto& b, const auto& b0) { return DescriptorT::Distance(a, a0, b, b0, m_tuning); } }
             {
                 m_tuning = DescriptorT::DEFAULT_TUNING;
@@ -253,7 +253,7 @@ namespace carl::action
             }
 
         private:
-            typename Signal<gsl::span<const DescriptorT>>::TicketT m_ticket;
+            typename Signal<gsl::span<const DescriptorT>, size_t>::TicketT m_ticket;
             std::vector<std::vector<DescriptorT>> m_templates{};
             std::vector<std::vector<DescriptorT>> m_countertemplates{};
             size_t m_trimmedSequenceLength{};
@@ -307,11 +307,11 @@ namespace carl::action
             {
                 // Select which recording is the "centroid"
                 // TODO: This does not currently take counterexamples into account very well since they won't apply AT the site of the score.
-                NumberT maxScore = calculateScore(m_templates[0]);
+                NumberT maxScore = calculateScore(m_templates[0], m_templates[0].size());
                 size_t maxIdx = 0;
                 for (size_t idx = 1; idx < m_templates.size(); ++idx)
                 {
-                    NumberT score = calculateScore(m_templates[idx]);
+                    NumberT score = calculateScore(m_templates[idx], m_templates[idx].size());
                     if (score > maxScore)
                     {
                         maxScore = score;
@@ -347,13 +347,14 @@ namespace carl::action
 
             NumberT calculateMatchDistance(
                 gsl::span<const DescriptorT> target,
-                gsl::span<const DescriptorT> query) const
+                gsl::span<const DescriptorT> query,
+                size_t minimumImageEndIdx = 0) const
             {
-                auto result = DynamicTimeWarping::Match(target, query, m_distanceFunction);
+                auto result = DynamicTimeWarping::Match(target, query, m_distanceFunction, minimumImageEndIdx);
                 return result.MatchCost / result.Connections;
             }
 
-            NumberT calculateScore(gsl::span<const DescriptorT> sequence) const
+            NumberT calculateScore(gsl::span<const DescriptorT> sequence, size_t newDescriptorsCount) const
             {
                 // Early-out if the provided sequence is too short.
                 if (sequence.size() <= m_trimmedSequenceLength)
@@ -376,12 +377,14 @@ namespace carl::action
                     return 0;
                 }
 
+                const size_t firstNewDescriptorIdx = trimmedSequence.size() - newDescriptorsCount;
+
                 // Calculate the base score based on proximity to templates
                 score = std::numeric_limits<NumberT>::lowest();
                 NumberT minDistance = std::numeric_limits<NumberT>::max();
                 for (const auto& t : m_templates)
                 {
-                    NumberT distance = calculateMatchDistance(trimmedSequence, t);
+                    NumberT distance = calculateMatchDistance(trimmedSequence, t, firstNewDescriptorIdx);
                     score = std::max(m_scoringFunction(distance), score);
                     minDistance = std::min(distance, minDistance);
                 }
@@ -393,7 +396,7 @@ namespace carl::action
                 NumberT minCounterDistance = std::numeric_limits<NumberT>::max();
                 for (const auto& t : m_countertemplates)
                 {
-                    NumberT distance = calculateMatchDistance(trimmedSequence, t);
+                    NumberT distance = calculateMatchDistance(trimmedSequence, t, firstNewDescriptorIdx);
                     minCounterDistance = std::min(distance, minCounterDistance);
                 }
                 if (minDistance >= minCounterDistance)
@@ -404,9 +407,9 @@ namespace carl::action
                 return score;
             }
 
-            void handleSequence(gsl::span<const DescriptorT> sequence)
+            void handleSequence(gsl::span<const DescriptorT> sequence, size_t newDescriptorsCount)
             {
-                auto score = calculateScore(sequence);
+                auto score = calculateScore(sequence, newDescriptorsCount);
                 if (!m_recognition && score > 0.7)
                 {
                     m_recognition = true;

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -377,7 +377,7 @@ namespace carl::action
                     return 0;
                 }
 
-                const size_t firstNewDescriptorIdx = trimmedSequence.size() - newDescriptorsCount;
+                const size_t firstNewDescriptorIdx = newDescriptorsCount <= trimmedSequence.size() ? trimmedSequence.size() - newDescriptorsCount : 0;
 
                 // Calculate the base score based on proximity to templates
                 score = std::numeric_limits<NumberT>::lowest();

--- a/CARL/source/Recognizer.cpp
+++ b/CARL/source/Recognizer.cpp
@@ -452,6 +452,10 @@ namespace carl::action
                 return std::make_unique<RecognizerImpl<descriptor::ControllerGesture<descriptor::Handedness::RightHanded>>>(session, definition.getExamples(), definition.getCounterexamples(), definition.DefaultSensitivity);
             case action::Definition::ActionType::TwoControllerGesture:
                 return std::make_unique<RecognizerImpl<descriptor::TwoControllerGesture>>(session, definition.getExamples(), definition.getCounterexamples(), definition.DefaultSensitivity);
+            case action::Definition::ActionType::LeftWristTrajectory:
+                return std::make_unique<RecognizerImpl<descriptor::WristTrajectory<descriptor::Handedness::LeftHanded>>>(session, definition.getExamples(), definition.getCounterexamples(), definition.DefaultSensitivity);
+            case action::Definition::ActionType::RightWristTrajectory:
+                return std::make_unique<RecognizerImpl<descriptor::WristTrajectory<descriptor::Handedness::RightHanded>>>(session, definition.getExamples(), definition.getCounterexamples(), definition.DefaultSensitivity);
             default:
                 throw std::runtime_error{ "Unknown definition type" };
             }

--- a/CARL/source/Session.cpp
+++ b/CARL/source/Session.cpp
@@ -107,7 +107,7 @@ namespace carl
     {
     }
 
-    void Session::addInput(InputSample inputSample)
+    void Session::addInput(const InputSample& inputSample)
     {
         m_impl->addInputSample(inputSample);
     }

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -115,7 +115,9 @@ namespace carl
         descriptor::TwoHandGesture,
         descriptor::ControllerGesture<descriptor::Handedness::LeftHanded>,
         descriptor::ControllerGesture<descriptor::Handedness::RightHanded>,
-        descriptor::TwoControllerGesture>
+        descriptor::TwoControllerGesture,
+        descriptor::WristTrajectory<descriptor::Handedness::LeftHanded>,
+        descriptor::WristTrajectory<descriptor::Handedness::RightHanded>>
     {
     public:
         Impl(bool singleThreaded);

--- a/CARL/source/SessionImpl.h
+++ b/CARL/source/SessionImpl.h
@@ -23,10 +23,10 @@ namespace carl
     template<typename DescriptorT, typename = std::enable_if_t<std::is_trivially_copyable_v<DescriptorT>>>
     class DescriptorSequence
     {
-        using WeakTableT = arcana::weak_table<typename Signal<gsl::span<const DescriptorT>>::HandlerT>;
+        using WeakTableT = arcana::weak_table<typename Signal<gsl::span<const DescriptorT>, size_t>::HandlerT>;
 
     public:
-        using DescriptorSignalT = Signal<gsl::span<const DescriptorT>>;
+        using DescriptorSignalT = Signal<gsl::span<const DescriptorT>, size_t>;
 
         class Provider : private WeakTableT, public DescriptorSignalT
         {
@@ -40,27 +40,27 @@ namespace carl
 
             void handleInputSamples(gsl::span<const InputSample> samples)
             {
-                bool descriptorsAdded = false;
+                size_t descriptorsAddedCount = 0;
                 for (const auto& sample : samples)
                 {
-                    descriptorsAdded = descriptorsAdded || handleInputSample(sample);
+                    descriptorsAddedCount += handleInputSample(sample);
                 }
 
-                if (descriptorsAdded)
+                if (descriptorsAddedCount > 0)
                 {
                     auto& handlers = *static_cast<WeakTableT*>(this);
-                    handlers.apply_to_all([this](auto& callable) {
-                        gsl::span<const DescriptorT> span{ m_sequence };
-                        callable(span);
+                    gsl::span<const DescriptorT> span{ m_sequence };
+                    handlers.apply_to_all([this, span, descriptorsAddedCount](auto& callable) mutable {
+                        callable(span, descriptorsAddedCount);
                     });
                 }
             }
 
-            bool handleInputSample(const InputSample& sample)
+            size_t handleInputSample(const InputSample& sample)
             {
                 size_t priorSequenceSize = m_sequence.size();
                 descriptor::extendSequence(sample, m_sequence, m_mostRecentSample, DescriptorT::DEFAULT_TUNING);
-                bool descriptorsAdded = m_sequence.size() > priorSequenceSize;
+                size_t descriptorsAddedCount = m_sequence.size() - priorSequenceSize;
 
                 if (m_sequence.size() > m_sequenceLength)
                 {
@@ -73,7 +73,7 @@ namespace carl
                     m_buffer.swap(m_sequence);
                 }
 
-                return descriptorsAdded;
+                return descriptorsAddedCount;
             }
 
             void supportSequenceOfLength(size_t length)
@@ -140,7 +140,7 @@ namespace carl
         }
 
         template <typename DescriptorT>
-        auto addHandler(std::function<void(gsl::span<const DescriptorT>)> handler)
+        auto addHandler(std::function<void(gsl::span<const DescriptorT>, size_t)> handler)
         {
             return DescriptorSequence<DescriptorT>::Provider::addHandler(std::move(handler));
         }

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -57,7 +57,7 @@ extern "C"
     C_API_EXPORT(double) getExampleStartTimestamp(uint64_t examplePtr);
     C_API_EXPORT(double) getExampleEndTimestamp(uint64_t examplePtr);
     C_API_EXPORT(void) disposeExample(uint64_t examplePtr);
-    C_API_EXPORT(uint64_t) createdDefinition(uint64_t descriptorType);
+    C_API_EXPORT(uint64_t) createDefinition(uint64_t descriptorType);
     C_API_EXPORT(void) addExample(uint64_t definitionPtr, uint64_t recordingPtr, double startTimestamp, double endTimestamp);
     C_API_EXPORT(void) addCounterexample(uint64_t definitionPtr, uint64_t recordingPtr, double startTimestamp, double endTimestamp);
     C_API_EXPORT(double) getDefaultSensitivity(uint64_t definitionPtr);
@@ -213,7 +213,7 @@ void disposeExample(uint64_t examplePtr)
     delete ptr;
 }
 
-uint64_t createdDefinition(uint64_t descriptorType)
+uint64_t createDefinition(uint64_t descriptorType)
 {
     auto* ptr = new carl::action::Definition(static_cast<carl::action::Definition::ActionType>(descriptorType));
     return reinterpret_cast<uint64_t>(ptr);

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -331,7 +331,8 @@ void tickCallbacks(uint64_t sessionPtr)
 void addInputSample(uint64_t sessionPtr, uint8_t* bytes, uint64_t size)
 {
     auto& session = *reinterpret_cast<carl::Session*>(sessionPtr);
-    carl::InputSample sample{ carl::Deserialization{bytes} };
+    carl::Deserialization deserialization{ bytes };
+    carl::InputSample sample{ deserialization };
     session.addInput(sample);
 }
 

--- a/Targets/c_api/main.cpp
+++ b/Targets/c_api/main.cpp
@@ -331,8 +331,8 @@ void tickCallbacks(uint64_t sessionPtr)
 void addInputSample(uint64_t sessionPtr, uint8_t* bytes, uint64_t size)
 {
     auto& session = *reinterpret_cast<carl::Session*>(sessionPtr);
-    carl::Deserialization deserialization{ bytes };
-    session.addInput({ deserialization });
+    carl::InputSample sample{ carl::Deserialization{bytes} };
+    session.addInput(sample);
 }
 
 void disposeSession(uint64_t sessionPtr)


### PR DESCRIPTION
Previously, controllers were supported in CARL only indirectly by simply treating controllers as hands. With this change, controllers are closer to becoming a priority use case, with a number of bug fixes, refinements for robustification and false positive reduction, and a new action type which ignores everything except "wrist" trajectory.

Note that, in the absence of joint data, "wrist" is simply any pose in space and could be anything. This fact should be reflected in the variable names, but that is not done in this PR and should be folded into a future refactor/restructure PR.

Also, one consequence of the robustification work done here is that default recognition envelopes have shrunk, in some cases significantly, meaning that in order to reach "ease of activation" parity with prior behavior, sensitivity must in some cases be significantly higher (depending on the definition) to counteract more restrictive tunings. The flip side of this is that, with lower sensitivity, it is now possible to recognize more precise actions, which was not achievable before. The balance between these concerns is incomplete and still not fully understood, and future work will further refine and eventually concretize this behavior.